### PR TITLE
Fix exception when displaying the Data API popup

### DIFF
--- a/ckanext/odata/templates/ajax_snippets/api_info.html
+++ b/ckanext/odata/templates/ajax_snippets/api_info.html
@@ -10,7 +10,8 @@ Example
     {% snippet 'ajax_snippets/api_info.html', datastore_root_url=datastore_root_url, resource_id=resource_id, embedded=true %}
 
 #}
-{% set sql_example_url = datastore_root_url + '/datastore_search_sql?sql=SELECT * from "' + resource_id + '" WHERE title LIKE \'jones\'' %}
+{% set resource_id = h.sanitize_id(resource_id) %}
+{% set sql_example_url = h.url_for(controller='api', action='action', ver=3, logic_function='datastore_search_sql', qualified=True) + '?sql=SELECT * from "' + resource_id + '" WHERE title LIKE \'jones\'' %}
 
 <div{% if not embedded %} class="modal"{% endif %}>
   <div class="modal-header">


### PR DESCRIPTION
The Data API popup was refactored in CKAN core to avoid dangerous parameters. The version on the extension contained undefined variables that cause an exception on the latest patch releases.